### PR TITLE
bugfix/accurics_remediation_43729836874515593 - Auto Generated Pull Request From Accurics

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -26,5 +26,10 @@ resource "aws_instance" "web" {
   }
 
 
+
+  metadata_options {
+    http_endpoint = "disabled"
+    http_tokens   = "required"
+  }
 }
 


### PR DESCRIPTION
IMDv1 is vulnerable to SSRF attack. Thus, EC2 Instance should have metadata_options block with either http_endpoint attribute set to disabled or ensure http_tokens attribute is set to required. This ensures IMDv2 is being used.